### PR TITLE
run CI also on pull_request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name:
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test_conda:


### PR DESCRIPTION
This enables testing for pull requests. 

Don't understand why CI runs for https://github.com/aCLImatise/CliHelpParser/pull/7 but did not for https://github.com/aCLImatise/CliHelpParser/pull/15 ... ?