### PR TITLE
emulate the behavior of subprocess.run(check=True)

### DIFF
--- a/acclimatise/execution.py
+++ b/acclimatise/execution.py
@@ -52,6 +52,9 @@ def execute_cmd(help_cmd: typing.List[str], timeout: int = 5, **kwargs) -> str:
             )
             process.communicate()
             return ""
+        else:
+            if process.returncode != 0:
+                raise subprocess.CalledProcessError
         finally:
             os.close(master)
             os.close(slave)


### PR DESCRIPTION
Popen has no parameter check, but this is assumed here:

https://github.com/aCLImatise/BiocondaCli/blob/929563213c9c44ea920c27ea499abefaa299587c/bioconda_cli/util.py#L210

not sure if the `finally` part runs in case of non-zero exit code.

Also not that I stumbled over programs that return 1 when called with `--help` ... but I guess we can't deal with that.