### PR TITLE
Remove cwlgen as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
         "pyparsing",
         "jinja2",
         "spacy",
-        "cwlgen",
         "miniwdl",
         "wordsegment",
         "inflection",


### PR DESCRIPTION
I can't see it being used in the repo, and it might cause other dependency issues as the project is deprecated.