### PR TITLE
Add man executor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: apt dependencies, and fix the `man` pages
         run: |
           rm /etc/dpkg/dpkg.cfg.d/docker
-          apt-get update && apt install -y --reinstall man coreutils manpages build-essential git
+          apt-get update && apt install -y --reinstall man coreutils manpages build-essential git git-man
           mandb --create
 
       - uses: actions/setup-dotnet@v1.7.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: apt dependencies, and fix the `man` pages
         run: |
           rm /etc/dpkg/dpkg.cfg.d/docker
-          apt-get update && apt install -y --reinstall man coreutils manpages build-essential
+          apt-get update && apt install -y --reinstall man coreutils manpages build-essential git
           mandb --create
 
       - uses: actions/setup-dotnet@v1.7.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: apt dependencies
-        run: apt-get update && apt install build-essential -y
+        run: apt-get update && apt install build-essential man -y
 
       - uses: actions/setup-dotnet@v1.7.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: apt dependencies
         run: apt-get update && apt install build-essential -y
 
-      - uses: actions/setup-dotnet@v1.6.0
+      - uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: "2.1.x"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: apt dependencies
-        run: apt-get update && apt install build-essential man -y
+      - name: apt dependencies, and fix the `man` pages
+        run: |
+          rm /etc/dpkg/dpkg.cfg.d/docker
+          apt-get update && apt install -y --reinstall man coreutils manpages build-essential
+          mandb --create
 
       - uses: actions/setup-dotnet@v1.7.2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.1.2
     hooks:
       - id: prettier

--- a/aclimatise/__init__.py
+++ b/aclimatise/__init__.py
@@ -1,162 +1,23 @@
-import logging
-import pty
-import subprocess
 import typing
-
-import dataclasses
-import psutil
-from pyparsing import ParseBaseException
 
 from aclimatise.converter import WrapperGenerator
 from aclimatise.converter.cwl import CwlGenerator
 from aclimatise.converter.wdl import WdlGenerator
 from aclimatise.converter.yml import YmlGenerator
 from aclimatise.execution import Executor
+from aclimatise.execution.docker import DockerExecutor
 from aclimatise.execution.local import LocalExecutor
-from aclimatise.flag_parser.parser import CliParser
+from aclimatise.execution.man import ManPageExecutor
+from aclimatise.integration import parse_help
 from aclimatise.model import Command, Flag
-from aclimatise.usage_parser.parser import UsageParser
-
-logger = logging.getLogger("aclimatise")
+from deprecated import deprecated
 
 default_executor = LocalExecutor()
 
 
-def _combine_flags(
-    flag_lists: typing.Iterable[typing.Iterable[Flag]],
-) -> typing.Iterable[Flag]:
-    """
-    Combines the flags from several sources, choosing the first one preferentially
-    """
-    lookup = {}
-
-    # Build a list of flags, but only ever choose the first instance of a synonym
-    for flags in flag_lists:
-        for flag in flags:
-            for synonym in flag.synonyms:
-                stripped = synonym.lstrip("-")
-                if stripped not in lookup:
-                    lookup[stripped] = flag
-
-    # Now, make them unique by description
-    unique = {flag.longest_synonym: flag for flag in lookup.values()}
-
-    return list(unique.values())
-
-
-def parse_help(cmd: typing.Collection[str], text: str, max_length=1000) -> Command:
-    """
-    Parse a string of help text into a Command. Use this if you already have run the executable and extracted the
-    help text yourself
-
-    :param cmd: List of arguments used to generate this help text, e.g. ['bwa', 'mem']
-    :param text: The help text to parse
-    :param max_length: If the input text has more than this many lines, no attempt will be made to parse the file (as
-        it's too large, will likely take a long time, and there's probably an underlying problem if this has happened).
-        In this case, an empty Command will be returned
-    """
-    if len(text.splitlines()) > max_length:
-        return Command(list(cmd))
-
-    help_command = CliParser().parse_command(name=cmd, cmd=text)
-    usage_command = UsageParser().parse_usage(list(cmd), text)
-
-    # Combine the two commands by picking from the help_command where possible, otherwise falling back on the usage
-    fields = dict(
-        help_text=text,
-        # Use the help command's positionals preferentially, but fall back to usage
-        positional=help_command.positional or usage_command.positional,
-        # Combine the flags from both help and usage
-        named=list(_combine_flags([help_command.named, usage_command.named])),
-    )
-    for field in dataclasses.fields(Command):
-        fields[field.name] = (
-            fields.get(field.name)
-            or getattr(help_command, field.name)
-            or getattr(usage_command, field.name)
-        )
-
-    return Command(**fields)
-
-
-def best_cmd(
-    cmd: typing.List[str],
-    flags: typing.Iterable[str] = (["--help"], ["-h"], [], ["--usage"]),
-    executor: Executor = default_executor,
-) -> Command:
-    """
-    Determine the best Command instance for a given command line tool, by trying many
-    different help flags, such as --help and -h, then return the Command. Use this if you know the command you want to
-    parse, but you don't know which flags it responds to with help text. Unlike :py:func:`aclimatise.explore_command`,
-    this doesn't even attempt to parse subcommands.
-
-    :param cmd: The command to analyse, e.g. ['wc'] or ['bwa', 'mem']
-    :param flags: A list of help flags to try, e.g. ['--help', '-h'], in order how which one you would prefer to use.
-    Generally [] aka no flags should be last
-    :param executor: A class that provides the means to run a command. You can use the pre-made classes or write your own.
-    """
-    # For each help flag, run the command and then try to parse it
-    logger.info("Trying flags for {}".format(" ".join(cmd)))
-    commands = []
-    for flag in flags:
-        help_cmd = cmd + flag
-        logger.info("Trying {}".format(" ".join(help_cmd)))
-        try:
-            final = executor.execute(help_cmd)
-            result = parse_help(cmd, final)
-            result.generated_using = flag
-            commands.append(result)
-        except (ParseBaseException, UnicodeDecodeError) as e:
-            # If parsing fails, this wasn't the right flag to use
-            continue
-
-    # Sort by flags primarily, and if they're equal, return the command with the longest help text, and if they're equal
-    # return the command with the most help flags. This helps ensure we get ["bedtools", "--help"] instead of
-    # ["bedtools"]
-    best = max(
-        commands,
-        key=lambda com: (
-            len(com.named) + len(com.positional),
-            # len(com.help_text) if com.help_text else 0,
-        ),
-    )
-    logger.info(
-        "The best help flag seems to be {}".format(
-            " ".join(best.command + best.generated_using)
-        )
-    )
-    return best
-
-
-def is_subcommand(command: Command, parent: Command) -> bool:
-    """
-    Returns true if command is a valid subcommand, relative to its parent
-    """
-    # Recursively call this on all ancestors
-    if parent.parent is not None and not is_subcommand(command, parent.parent):
-        return False
-
-    # This isn't a subcommand if it has the same input text as the parent
-    if command.help_text and command.help_text == parent.help_text:
-        return False
-
-    # This isn't a subcommand if it has no flags
-    if len(command.positional) + len(command.named) == 0:
-        return False
-
-    # This isn't a subcommand if it shares any positional with the parent command
-    for pos_a, pos_b in zip(parent.positional, command.positional):
-        if pos_a == pos_b:
-            return False
-
-    # This isn't a subcommand if it shares any flags with the parent command
-    for flag_a, flag_b in zip(parent.named, command.named):
-        if flag_a == flag_b:
-            return False
-
-    return True
-
-
+@deprecated(
+    reason="Please use the explore method on the executors directly. e.g. `LocalExecutor().explore()`"
+)
 def explore_command(
     cmd: typing.List[str],
     flags: typing.Iterable[str] = (["--help"], ["-h"], [], ["--usage"]),
@@ -169,48 +30,17 @@ def explore_command(
     Given a command to start with, builds a model of this command and all its subcommands (if they exist).
     Use this if you know the command you want to parse, you don't know which flags it responds to with help text, and
     you want to include subcommands.
-
-    :param cmd: Command line executable and arguments to explore
-    :param flags: A list of help flags to try, e.g. ['--help', '-h'], in order how which one you would prefer to use.
-    Generally [] aka no flags should be last
-    :param parent: A parent Command to add this command to as a subcommand, if this command actually exists
-    :param executor: A class that provides the means to run a command. You can use the pre-made classes or write your own.
-    :param try_subcommand_flags: If true, try all the ``flags`` on each subcommand. If False, we choose
-    the best help flag on the parent command and then use that same one on each child. Generally True is recommended
-    since some tools (such as bedtools) use different help flags for subcommands
     """
-    logger.info("Exploring {}".format(" ".join(cmd)))
-    command = best_cmd(cmd, flags, executor=executor)
+    return executor.explore(cmd, max_depth=max_depth, parent=parent)
 
-    # Check if this is a valid subcommand
-    if parent:
-        if is_subcommand(command, parent):
-            logger.info("{} seems to be a valid subcommand".format(" ".join(cmd)))
-            command.parent = parent
-        else:
-            logger.info(
-                "{} does not seem to be a valid subcommand".format(" ".join(cmd))
-            )
-            return None
 
-    # Recursively call this function on positionals, but only do this if we aren't at max depth
-    if command.depth < max_depth:
-        # By default we use the best parent help-flag
-        child_flags = flags if try_subcommand_flags else [command.generated_using]
-
-        # Try each *unique* positional
-        for positional in {positional.name for positional in command.positional}:
-            subcommand = explore_command(
-                cmd=cmd + [positional],
-                flags=child_flags,
-                parent=command,
-                max_depth=max_depth,
-                executor=executor,
-                try_subcommand_flags=try_subcommand_flags,
-            )
-            if subcommand is not None:
-                command.subcommands.append(subcommand)
-                # If we had any subcommands then we probably don't have any positionals, or at least don't care about them
-                command.positional = []
-
-    return command
+__all__ = [
+    CwlGenerator,
+    WdlGenerator,
+    YmlGenerator,
+    LocalExecutor,
+    DockerExecutor,
+    ManPageExecutor,
+    explore_command,
+    parse_help,
+]

--- a/aclimatise/execution/__init__.py
+++ b/aclimatise/execution/__init__.py
@@ -2,16 +2,20 @@
 This module is concerned with running the actual commands so that we can parse their output
 """
 import abc
-from typing import List
+from typing import List, Optional
+
+from aclimatise.model import Command
 
 
 class Executor(abc.ABC):
     """
     An executor is anything that can take a command such as ["bwa"] or
-    ["samtools", "sort"] and return the output
+    ["samtools", "sort"] and return the help output
     """
 
-    def __init__(self, timeout: int = 10, raise_on_timout=False):
+    def __init__(
+        self, timeout: int = 10, raise_on_timout=False, max_length: Optional[int] = None
+    ):
         """
         :param timeout: Amount of inactivity before the execution will be killed
         :param raise_on_timout: If true, execute will raise a TimeoutError if it
@@ -20,6 +24,7 @@ class Executor(abc.ABC):
         # Here we initialise all shared parameters that are used by all executors
         self.timeout = timeout
         self.raise_on_timeout = raise_on_timout
+        self.max_length = max_length
 
     def handle_timeout(self, e: Exception) -> str:
         """
@@ -32,8 +37,13 @@ class Executor(abc.ABC):
             return ""
 
     @abc.abstractmethod
-    def execute(self, command: List[str]) -> str:
+    def explore(
+        self,
+        command: List[str],
+        max_depth: int = 2,
+        parent: Optional[Command] = None,
+    ) -> Command:
         """
-        Execute a command defined by a list of arguments, and return the result as a string
+        Given a command to start with, builds a model of this command and all its subcommands (if they exist)
         """
         pass

--- a/aclimatise/execution/__init__.py
+++ b/aclimatise/execution/__init__.py
@@ -14,7 +14,7 @@ class Executor(abc.ABC):
     """
 
     def __init__(
-        self, timeout: int = 10, raise_on_timout=False, max_length: Optional[int] = None
+        self, timeout: int = 10, raise_on_timout=False, max_length: Optional[int] = 1000
     ):
         """
         :param timeout: Amount of inactivity before the execution will be killed
@@ -36,7 +36,6 @@ class Executor(abc.ABC):
         else:
             return ""
 
-    @abc.abstractmethod
     def explore(
         self,
         command: List[str],
@@ -45,5 +44,13 @@ class Executor(abc.ABC):
     ) -> Command:
         """
         Given a command to start with, builds a model of this command and all its subcommands (if they exist)
+        """
+        # If the executor doesn't implement a specific exploration technique, we just execute and ignore subcommands
+        return self.execute(command)
+
+    @abc.abstractmethod
+    def execute(self, command: List[str]) -> Command:
+        """
+        Convert a single executable to a Command object, without considering subcommands
         """
         pass

--- a/aclimatise/execution/__init__.py
+++ b/aclimatise/execution/__init__.py
@@ -46,10 +46,10 @@ class Executor(abc.ABC):
         Given a command to start with, builds a model of this command and all its subcommands (if they exist)
         """
         # If the executor doesn't implement a specific exploration technique, we just execute and ignore subcommands
-        return self.execute(command)
+        return self.convert(command)
 
     @abc.abstractmethod
-    def execute(self, command: List[str]) -> Command:
+    def convert(self, command: List[str]) -> Command:
         """
         Convert a single executable to a Command object, without considering subcommands
         """

--- a/aclimatise/execution/docker.py
+++ b/aclimatise/execution/docker.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from docker.utils.socket import consume_socket_output, demux_adaptor, frames_iter
 
-from . import Executor
+from aclimatise.execution.help import CliHelpExecutor
 
 
 def read_socket(sock, timeout: int = None) -> Tuple[bytes, bytes]:
@@ -35,7 +35,7 @@ def read_socket(sock, timeout: int = None) -> Tuple[bytes, bytes]:
     return tuple(out)
 
 
-class DockerExecutor(Executor):
+class DockerExecutor(CliHelpExecutor):
     """
     An executor that runs the commands on an already-running docker Container (not an Image!)
     """

--- a/aclimatise/execution/help.py
+++ b/aclimatise/execution/help.py
@@ -1,0 +1,116 @@
+import copy
+import logging
+from typing import Iterable, List, Optional
+
+from pyparsing import ParseBaseException
+
+from aclimatise.execution import Executor
+from aclimatise.integration import parse_help
+from aclimatise.model import Command
+
+logger = logging.getLogger()
+
+
+class CliHelpExecutor(Executor):
+    """
+    This is an abstract class for any executor that works with command-line help conventions like using help flags in
+    order to obtain the help text.
+    """
+
+    def __init__(
+        self,
+        flags: Iterable[str] = (["--help"], ["-h"], [], ["--usage"]),
+        try_subcommand_flags=True,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.flags = flags
+        self.try_subcommand_flags = try_subcommand_flags
+
+    def explore(
+        self,
+        command: List[str],
+        max_depth: int = 2,
+        parent: Optional[Command] = None,
+    ) -> Optional[Command]:
+
+        logger.info("Exploring {}".format(" ".join(command)))
+        best = self.best_cmd(command)
+
+        # Check if this is a valid subcommand
+        if parent:
+            if best.valid_subcommand():
+                logger.info(
+                    "{} seems to be a valid subcommand".format(" ".join(command))
+                )
+                best.parent = parent
+            else:
+                logger.info(
+                    "{} does not seem to be a valid subcommand".format(
+                        " ".join(command)
+                    )
+                )
+                return None
+
+        # Recursively call this function on positionals, but only do this if we aren't at max depth
+        if best.depth < max_depth:
+            # By default we use the best parent help-flag
+            child_executor = copy.copy(self)
+            child_executor.flags = (
+                self.flags if self.try_subcommand_flags else [best.generated_using]
+            )
+
+            # Try each *unique* positional
+            for positional in {positional.name for positional in best.positional}:
+                subcommand = child_executor.explore(
+                    command=command + [positional],
+                    parent=best,
+                    max_depth=max_depth,
+                )
+                if subcommand is not None:
+                    best.subcommands.append(subcommand)
+                    # If we had any subcommands then we probably don't have any positionals, or at least don't care about them
+                    best.positional = []
+
+        return best
+
+    def best_cmd(
+        self,
+        cmd: List[str],
+    ) -> Command:
+        """
+        Determine the best Command instance for a given command line tool, by trying many
+        different help flags, such as --help and -h, then return the Command. Use this if you know the command you want to
+        parse, but you don't know which flags it responds to with help text. Unlike :py:func:`aclimatise.explore_command`,
+        this doesn't even attempt to parse subcommands.
+
+        :param cmd: The command to analyse, e.g. ['wc'] or ['bwa', 'mem']
+        :param flags: A list of help flags to try, e.g. ['--help', '-h'], in order how which one you would prefer to use.
+        Generally [] aka no flags should be last
+        :param executor: A class that provides the means to run a command. You can use the pre-made classes or write your own.
+        """
+        # For each help flag, run the command and then try to parse it
+        logger.info("Trying flags for {}".format(" ".join(cmd)))
+        commands = []
+        for flag in self.flags:
+            help_cmd = cmd + flag
+            logger.info("Trying {}".format(" ".join(help_cmd)))
+            try:
+                final = self.execute(help_cmd)
+                result = parse_help(cmd, final, max_length=self.max_length)
+                result.generated_using = flag
+                commands.append(result)
+            except (ParseBaseException, UnicodeDecodeError) as e:
+                # If parsing fails, this wasn't the right flag to use
+                continue
+
+        # Sort by flags primarily, and if they're equal, return the command with the longest help text, and if they're equal
+        # return the command with the most help flags. This helps ensure we get ["bedtools", "--help"] instead of
+        # ["bedtools"]
+        best = Command.best(commands)
+        logger.info(
+            "The best help flag seems to be {}".format(
+                " ".join(best.command + best.generated_using)
+            )
+        )
+        return best

--- a/aclimatise/execution/help.py
+++ b/aclimatise/execution/help.py
@@ -1,3 +1,4 @@
+import abc
 import copy
 import logging
 from typing import Iterable, List, Optional
@@ -35,7 +36,8 @@ class CliHelpExecutor(Executor):
     ) -> Optional[Command]:
 
         logger.info("Exploring {}".format(" ".join(command)))
-        best = self.execute(command)
+        best = self.convert(command)
+        best.parent = parent
 
         # Check if this is a valid subcommand
         if parent:
@@ -43,7 +45,6 @@ class CliHelpExecutor(Executor):
                 logger.info(
                     "{} seems to be a valid subcommand".format(" ".join(command))
                 )
-                best.parent = parent
             else:
                 logger.info(
                     "{} does not seem to be a valid subcommand".format(
@@ -74,7 +75,14 @@ class CliHelpExecutor(Executor):
 
         return best
 
-    def execute(
+    @abc.abstractmethod
+    def execute(self, cmd: List[str]) -> str:
+        """
+        Executes the provided command and returns a string containing the output
+        """
+        pass
+
+    def convert(
         self,
         cmd: List[str],
     ) -> Command:

--- a/aclimatise/execution/help.py
+++ b/aclimatise/execution/help.py
@@ -35,7 +35,7 @@ class CliHelpExecutor(Executor):
     ) -> Optional[Command]:
 
         logger.info("Exploring {}".format(" ".join(command)))
-        best = self.best_cmd(command)
+        best = self.execute(command)
 
         # Check if this is a valid subcommand
         if parent:
@@ -74,7 +74,7 @@ class CliHelpExecutor(Executor):
 
         return best
 
-    def best_cmd(
+    def execute(
         self,
         cmd: List[str],
     ) -> Command:

--- a/aclimatise/execution/local.py
+++ b/aclimatise/execution/local.py
@@ -10,7 +10,7 @@ from typing import List
 
 import psutil
 
-from . import Executor
+from aclimatise.execution.help import CliHelpExecutor
 
 
 def kill_proc_tree(pid, sig=signal.SIGTERM, include_parent=True):
@@ -29,7 +29,7 @@ def kill_proc_tree(pid, sig=signal.SIGTERM, include_parent=True):
         p.send_signal(sig)
 
 
-class LocalExecutor(Executor):
+class LocalExecutor(CliHelpExecutor):
     def __init__(self, popen_args: dict = {}, **kwargs):
         super().__init__(**kwargs)
         self.popen_args = popen_args

--- a/aclimatise/execution/man.py
+++ b/aclimatise/execution/man.py
@@ -44,7 +44,7 @@ class ManPageExecutor(Executor):
 
         return ""
 
-    def execute(self, command: List[str]) -> Command:
+    def convert(self, command: List[str]) -> Command:
         if len(command) == 1:
             return parse_help(
                 command, self.execute_with_sep(command), max_length=self.max_length

--- a/aclimatise/execution/man.py
+++ b/aclimatise/execution/man.py
@@ -26,7 +26,7 @@ class ManPageExecutor(Executor):
         self.subcommand_sep = subcommand_sep
         self.man_flags = man_flags
 
-    def execute(self, command: List[str], separator: str = "-") -> str:
+    def execute_with_sep(self, command: List[str], separator: str = "-") -> str:
         """
         Returns the man page text for the provided command, using the provided subcommand separator, or an empty string
         if this man page doesn't exist
@@ -44,17 +44,15 @@ class ManPageExecutor(Executor):
 
         return ""
 
-    def explore(
-        self, command: List[str], max_depth: int = 2, parent: Optional[Command] = None
-    ) -> Command:
+    def execute(self, command: List[str]) -> Command:
         if len(command) == 1:
             return parse_help(
-                command, self.execute(command), max_length=self.max_length
+                command, self.execute_with_sep(command), max_length=self.max_length
             )
         else:
             commands = []
             for sep in self.subcommand_sep:
-                man_text = self.execute(command, sep)
+                man_text = self.execute_with_sep(command, sep)
                 commands.append(
                     parse_help(command, man_text, max_length=self.max_length)
                 )

--- a/aclimatise/execution/man.py
+++ b/aclimatise/execution/man.py
@@ -1,0 +1,61 @@
+import os
+import subprocess
+from typing import Collection, List, Optional
+
+from aclimatise.execution import Executor
+from aclimatise.integration import parse_help
+from aclimatise.model import Command
+
+
+class ManPageExecutor(Executor):
+    def __init__(
+        self,
+        man_paths: List[str] = [],
+        subcommand_sep: Collection[str] = ("-", "_"),
+        man_flags: Collection[str] = ["--no-subpages"],
+        **kwargs
+    ):
+        """
+        :param man_paths: Additional paths within which to look for man pages
+        :param subcommand_sep: A list of separators to use to generate man paths from subcommands. For example
+            ``git branch`` has an associated man page at ``git-branch``, using the hyphen as a separator.
+        :param man_flags: Additional flags to pass to the ``man`` command
+        """
+        super().__init__(**kwargs)
+        self.man_paths = man_paths
+        self.subcommand_sep = subcommand_sep
+        self.man_flags = man_flags
+
+    def execute(self, command: List[str], separator: str = "-") -> str:
+        """
+        Returns the man page text for the provided command, using the provided subcommand separator, or an empty string
+        if this man page doesn't exist
+        """
+        env = {**os.environ.copy(), "MANPAGER": "cat"}  # Don't use a pager
+        if len(self.man_paths) > 0:
+            env.update({"MANPATH": ":".join(self.man_paths)})
+
+        sub_man = separator.join(command)
+        result = subprocess.run(
+            ["man", *self.man_flags, sub_man], env=env, capture_output=True
+        )
+        if result.returncode == 0:
+            return result.stdout.decode()
+
+        return ""
+
+    def explore(
+        self, command: List[str], max_depth: int = 2, parent: Optional[Command] = None
+    ) -> Command:
+        if len(command) == 1:
+            return parse_help(
+                command, self.execute(command), max_length=self.max_length
+            )
+        else:
+            commands = []
+            for sep in self.subcommand_sep:
+                man_text = self.execute(command, sep)
+                commands.append(
+                    parse_help(command, man_text, max_length=self.max_length)
+                )
+            return Command.best(commands)

--- a/aclimatise/execution/man.py
+++ b/aclimatise/execution/man.py
@@ -37,7 +37,10 @@ class ManPageExecutor(Executor):
 
         sub_man = separator.join(command)
         result = subprocess.run(
-            ["man", *self.man_flags, sub_man], env=env, capture_output=True
+            ["man", *self.man_flags, sub_man],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         if result.returncode == 0:
             return result.stdout.decode()

--- a/aclimatise/integration.py
+++ b/aclimatise/integration.py
@@ -1,0 +1,42 @@
+import typing
+
+import dataclasses
+
+from aclimatise.flag_parser.parser import CliParser
+from aclimatise.model import Command, Flag
+from aclimatise.usage_parser.parser import UsageParser
+
+
+def parse_help(cmd: typing.Collection[str], text: str, max_length=1000) -> Command:
+    """
+    Parse a string of help text into a Command. Use this if you already have run the executable and extracted the
+    help text yourself
+
+    :param cmd: List of arguments used to generate this help text, e.g. ['bwa', 'mem']
+    :param text: The help text to parse
+    :param max_length: If the input text has more than this many lines, no attempt will be made to parse the file (as
+        it's too large, will likely take a long time, and there's probably an underlying problem if this has happened).
+        In this case, an empty Command will be returned
+    """
+    if len(text.splitlines()) > max_length:
+        return Command(list(cmd))
+
+    help_command = CliParser().parse_command(name=cmd, cmd=text)
+    usage_command = UsageParser().parse_usage(list(cmd), text)
+
+    # Combine the two commands by picking from the help_command where possible, otherwise falling back on the usage
+    fields = dict(
+        help_text=text,
+        # Use the help command's positionals preferentially, but fall back to usage
+        positional=help_command.positional or usage_command.positional,
+        # Combine the flags from both help and usage
+        named=list(Flag.combine([help_command.named, usage_command.named])),
+    )
+    for field in dataclasses.fields(Command):
+        fields[field.name] = (
+            fields.get(field.name)
+            or getattr(help_command, field.name)
+            or getattr(usage_command, field.name)
+        )
+
+    return Command(**fields)

--- a/aclimatise/nlp.py
+++ b/aclimatise/nlp.py
@@ -34,7 +34,12 @@ def is_sentence(text: str, threshold: float = 0.8) -> bool:
     """
 
     doc = no_sentences(text)
-    sentence = list(doc.sents)[0]
+    sents = list(doc.sents)
+
+    if len(sents) == 0:
+        return False
+
+    sentence = sents[0]
     non_word_count = 0
     word_count = 0
     for tok in sentence:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,5 +1,14 @@
 Changelog
 =========
+
+3.0.0 (2020-11-)
+----------------
+* Rework of executors
+    * `explore` is now a method on the executor object
+    * Add a `man`-page executor
+    * `aclimatise.explore` is now deprecated
+
+
 2.2.0 (2020-09-26)
 ------------------
 * Add ``command.reanalyse()``, which re-analyses the help text stored in the command, using the current parser

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "word2number",
         "psutil",
         "dataclasses",
+        "deprecated",
     ],
     python_requires=">=3.6",
     entry_points={"console_scripts": ["aclimatise = aclimatise.cli:main"]},

--- a/test/executors/test_man.py
+++ b/test/executors/test_man.py
@@ -4,8 +4,18 @@ from aclimatise.execution.man import ManPageExecutor
 
 
 @skip_not_installed("git")
+@skip_not_installed("man")
 def test_git():
     cmd = ManPageExecutor(max_length=99999).explore(
         ["git"],
     )
     assert len(cmd.subcommands) > 20
+
+
+@skip_not_installed("git")
+@skip_not_installed("ls")
+def test_ls():
+    cmd = ManPageExecutor().explore(
+        ["ls"],
+    )
+    assert {"-A", "--almost-all", "-1", "--context"} <= cmd.all_synonyms

--- a/test/executors/test_man.py
+++ b/test/executors/test_man.py
@@ -1,0 +1,11 @@
+from test.util import skip_not_installed
+
+from aclimatise.execution.man import ManPageExecutor
+
+
+@skip_not_installed("git")
+def test_git():
+    cmd = ManPageExecutor(max_length=99999).explore(
+        ["git"],
+    )
+    assert len(cmd.subcommands) > 20

--- a/test/executors/test_man.py
+++ b/test/executors/test_man.py
@@ -9,7 +9,7 @@ def test_git():
     cmd = ManPageExecutor(max_length=99999).explore(
         ["git"],
     )
-    assert len(cmd.subcommands) > 20
+    assert len(cmd.positional) > 20
 
 
 @skip_not_installed("git")

--- a/test/flags/test_bwa.py
+++ b/test/flags/test_bwa.py
@@ -3,8 +3,8 @@ from textwrap import dedent
 
 import pytest
 
-from aclimatise import parse_help
 from aclimatise.flag_parser import elements
+from aclimatise.integration import parse_help
 from aclimatise.model import Flag, FlagSynonym, OptionalFlagArg
 
 

--- a/test/test_parse_e2e.py
+++ b/test/test_parse_e2e.py
@@ -4,7 +4,7 @@ import string
 import pytest
 from pkg_resources import resource_filename
 
-from aclimatise import parse_help
+from aclimatise.integration import parse_help
 
 from .util import (
     HelpText,

--- a/test/test_yaml_dump.py
+++ b/test/test_yaml_dump.py
@@ -1,6 +1,6 @@
 from io import StringIO
 
-from aclimatise import parse_help
+from aclimatise.integration import parse_help
 from aclimatise.yaml import yaml
 
 


### PR DESCRIPTION
Closes #59.

## TODO

* [ ] Fix how we handle subcommand detection for man pages. e.g. `man git` returns `git-add(1)` which is a man page reference to a subcommand
* [x] Get all tests passing
* [x] Provide a method for converting a single command without subcommands on the executor